### PR TITLE
fixes for scoping of local FDC3 instances when in a single DOM

### DIFF
--- a/components.html
+++ b/components.html
@@ -1,0 +1,140 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="style.css">
+        <style>
+            body {
+                background: #fff;
+                font-family: Arial, Helvetica, sans-serif;
+            }
+
+            .content {
+                width:calc(50vw - 2rem);
+            }
+    
+            .header {
+                display: flex;
+                flex-flow:row;
+                justify-content: center;
+                width:100%;
+            }
+    
+            .header .title {
+                width:100%;
+                font-size:32px;
+                font-weight:bold;
+                color: #eee;
+                margin-left: 0.6rem;
+                margin-bottom:.6rem;
+            }
+
+            .content .header {
+                height:42px;
+            }
+    
+            .content p {
+                margin-left:.6rem;
+            }
+            
+            .header h1 {
+                text-align:left;
+            }
+    
+            #channelPicker {
+                display: flex;
+                flex-flow: row;
+                margin-top:.6rem;
+                margin-right: .6rem;
+            }
+    
+            .channel {
+                height: 25px;
+                width: 25px;
+                text-align: center;
+                vertical-align: middle;
+                font-size: 19px;
+                font-family: monospace;
+                padding-top:0px;
+                margin-bottom: 0px;
+                color: #eee;
+                font-family: sans-serif;
+                font-variant-caps: all-small-caps;
+                border-radius:3px;
+                margin-left:1px;
+            }
+
+            .channel:hover {
+                cursor: pointer;
+                opacity:.8;
+                transition-property: opacity;
+                transition-duration: .3s;
+            }
+    
+            #broadcastButtons {
+                width: 100%;
+    
+            }
+    
+            .buttonContainer button {
+                margin-right: 3px;
+                margin-bottom: 3px;
+                border: 0px;
+                background: #36a;
+                color: #eee;
+                padding: 0px;
+                width: 130px;
+                height:40px;
+                border-radius: 3px;
+            }
+    
+            .contextField {
+                margin-left: 0.6rem;
+                margin-right: 0.6rem;
+                height: 200px;
+                background: #222;
+                color: #3a6;
+                padding: 3px;
+                font-family: monospace;
+                border-radius: 3px;
+                overflow-y: scroll;
+                overflow-wrap: normal;
+            }
+    
+    
+            .section {
+                margin-left: .6rem;
+                margin-right: .6rem;
+            }
+    
+    
+            .section h2 {
+                margin-left:.3rem;
+            }
+        </style>
+        <script type="module" src="/src/agent.ts"></script>
+
+    </head>
+    <body>
+        <div class='header'>
+            <h1>Connectifi Web Portal</h1>
+        </div>
+          <section>
+            <div class="content">
+             
+            </div>
+      
+            <div class="content">
+
+            </div>
+
+        </section>
+    </body>
+    <script type="module">
+        import { createComponent } from  "/src/component.ts";
+
+        const targets = document.querySelectorAll('.content');
+        targets.forEach(target => {
+            createComponent(target);
+        });
+    </script>
+</html>
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectifi/fdc3-web-portal",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectifi/fdc3-web-portal",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@connectifi/agent-web": "1.2.5",
         "@finos/fdc3": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@connectifi/fdc3-web-portal",
   "private": false,
-  "version": "0.0.91",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/main.umd.cjs",
   "module": "./dist/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@connectifi/fdc3-web-portal",
   "private": false,
-  "version": "0.0.9",
+  "version": "0.0.91",
   "type": "module",
   "main": "./dist/main.umd.cjs",
   "module": "./dist/main.js",

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,0 +1,151 @@
+import { createWebAgentAPI } from "./main";
+
+const companies = [
+    { "Name": "3M Company", "Sector": "Industrials", "Symbol": "MMM", "Contact": "Nick Kolba", "Email": "nkolba@gmail.com" },
+    { "Name": "A.O. Smith Corp", "Sector": "Industrials", "Symbol": "AOS", "Contact": "Seb Ben M'Barek", "Email": "sebastien.benmbarek@normanandsons.com" },
+    { "Name": "Abbott Laboratories", "Sector": "Health Care", "Symbol": "ABT", "Contact": "Rob Moffat", "Email": "rob.moffat@hsbc.com" },
+    { "Name": "AbbVie Inc.", "Sector": "Health Care", "Symbol": "ABBV", "Contact": "Nick Kolba", "Email": "nkolba@gmail.com" },
+    { "Name": "Abiomed", "Sector": "Health Care", "Symbol": "ABMD", "Contact": "Nick Kolba", "Email": "nkolba@gmail.com" },
+    { "Name": "Accenture plc", "Sector": "Information Technology", "Symbol": "ACN", "Contact": "Nick Kolba", "Email": "nkolba@gmail.com" },
+    { "Name": "Activision Blizzard", "Sector": "Information Technology", "Symbol": "ATVI", "Contact": "Rob Moffat", "Email": "rob.moffat@hsbc.com" },
+    { "Name": "ADM", "Sector": "IConsumer Staples", "Symbol": "ADM", "Contact": "Nick Kolba", "Email": "nkolba@gmail.com" },
+    { "Name": "Adobe Systems Inc", "Sector": "Information Technology", "Symbol": "ADBE", "Contact": "Seb Ben M'Barek", "Email": "sebastien.benmbarek@normanandsons.com" },
+    { "Name": "Advance Auto Parts", "Sector": "Consumer Discretionary", "Symbol": "AAP", "Contact": "Seb Ben M'Barek", "Email": "sebastien.benmbarek@normanandsons.com" },
+];
+
+export const createComponent = async ( target: HTMLElement ) => {
+    
+
+    const render = async (target: HTMLElement) => {
+        const componentWrapper = document.createElement("div");
+
+        const header = document.createElement("div");
+        header.classList.add('header');
+        const title = document.createElement("div");
+        title.classList.add('title');
+        title.textContent = 'App';
+        const channelPicker = document.createElement("div");
+        channelPicker.id = 'channelPicker';
+        header.appendChild(title);
+        header.appendChild(channelPicker);
+
+        const channels = await fdc3.getSystemChannels();
+    
+        channels.forEach(channel => {
+        const option = document.createElement("div");
+        option.classList.add('channel');
+        option.style.background = channel.id === 'global' ? '#999' : channel.displayMetadata?.color || '';
+        option.title = channel.id === 'global' ? 'no channel' : channel.id;
+        if (channel.id === 'global') {
+            option.textContent = 'X'
+        }
+        option.addEventListener('click', async () => {
+            if (channel.id === 'global') {
+                await fdc3.leaveCurrentChannel();
+            }
+            document.querySelectorAll('.channel').forEach(c => c.textContent = '');
+            option.textContent = 'X';
+    
+            await fdc3.joinChannel(channel.id);
+        });
+        channelPicker.appendChild(option);
+        })
+
+        componentWrapper.appendChild(header);
+
+        const description = document.createElement("p");
+        description.textContent = 'This is a demo of a portal app using in line components all in the same DOM but with different FDC3 scopes';
+
+        componentWrapper.appendChild(description);
+
+        const broadcastSection = document.createElement('div');
+        broadcastSection.classList.add('section');
+        const broadcastHeader = document.createElement('h2');
+        broadcastHeader.textContent = 'broadcast';
+        const broadcastButtonsContainer = document.createElement('div');
+        broadcastButtonsContainer.id = 'broadcastButtons';
+        broadcastButtonsContainer.classList.add('buttonContainer');
+        const contextHeader = document.createElement('h2');
+        contextHeader.textContent = 'context';
+        const contextFieldWrapper = document.createElement('div');
+        contextFieldWrapper.classList.add('contextField');
+        const contextField = document.createElement('pre');
+        contextField.id = 'contextField';
+        contextFieldWrapper.appendChild(contextField);
+
+        fdc3.addContextListener("fdc3.instrument", (context) => {
+            contextField.textContent = `${JSON.stringify(context)}\n${contextField.textContent}`;
+        });
+
+        companies.forEach(company => {
+            const button = document.createElement('button');
+            button.textContent = company.Name;
+            button.addEventListener('click', () => {
+                fdc3.broadcast({ 
+                    type: 'fdc3.instrument', 
+                    name: company.Name, 
+                    id: { 
+                        ticker: company.Symbol 
+                    }
+                });
+            });
+            broadcastButtonsContainer.appendChild(button);
+        });
+        
+
+        broadcastSection.appendChild(broadcastHeader);
+        broadcastSection.appendChild(broadcastButtonsContainer);
+        broadcastSection.appendChild(contextHeader);
+        broadcastSection.appendChild(contextFieldWrapper);
+
+        componentWrapper.appendChild(broadcastSection);
+
+        const intentsSection = document.createElement('div');
+        intentsSection.classList.add('section');
+        const intentsHeader = document.createElement('h2');
+        intentsHeader.textContent = 'intents';
+        const intentsButtonsContainer = document.createElement('div');
+        intentsButtonsContainer.id = 'intentButtons';
+        intentsButtonsContainer.classList.add('buttonContainer');
+        const intentsContextHeader = document.createElement('h2');
+        intentsContextHeader.textContent = 'intents for context';
+        const intentsContextButtonsContainer = document.createElement('div');
+        intentsContextButtonsContainer.id = 'intentContextButtons';
+        intentsContextButtonsContainer.classList.add('buttonContainer');
+
+        companies.forEach(company => {
+            const intentButton = document.createElement('button');
+            const intentContextButton = document.createElement('button');
+            intentButton.textContent = company.Name;
+            intentContextButton.textContent = company.Name;
+     
+            intentContextButton.addEventListener('click', () => {
+                    fdc3.raiseIntentForContext({ type: 'fdc3.instrument', id: { ticker: company.Symbol } });
+                });
+  
+            intentButton.addEventListener('click', () => {
+                    fdc3.raiseIntent('ViewChart',{ type: 'fdc3.instrument', id: { ticker: company.Symbol } });
+                
+                });
+      
+            intentsButtonsContainer.appendChild(intentButton);
+            intentsContextButtonsContainer.appendChild(intentContextButton);
+        });
+
+        intentsSection.appendChild(intentsHeader);
+        intentsSection.appendChild(intentsButtonsContainer);
+        intentsSection.appendChild(intentsContextHeader);
+        intentsSection.appendChild(intentsContextButtonsContainer);
+
+        componentWrapper.appendChild(intentsSection);
+
+        target.appendChild(componentWrapper);
+
+    };
+
+    const fdc3 = await createWebAgentAPI();
+
+    render(target);
+
+
+};

--- a/src/webAgentAPI/main.ts
+++ b/src/webAgentAPI/main.ts
@@ -1,18 +1,11 @@
-import { createAPI, setListener } from "./api";
+import { createAPI } from "./api";
 import { FDC3LocalInstance } from "./sendMessage";
-import { RegisterInstanceReturn } from "@/common/types";
 import { DesktopAgent } from "@finos/fdc3";
 
 export const createWebAgentAPI = async (): Promise<DesktopAgent> => {
   
   //instantiate a local instance
   const connection = new FDC3LocalInstance();
-  connection.setListener();
-  const registrationResult = await connection.sendMessage("registerInstance");
-  const instanceId = (registrationResult.data as RegisterInstanceReturn)
-    .instanceId;
-  console.log("*** API setting instanceId ", instanceId);
-  connection.instanceId = instanceId;
-
+  await connection.initConnection();
   return createAPI(connection);
 };

--- a/src/webAgentAPI/main.ts
+++ b/src/webAgentAPI/main.ts
@@ -1,15 +1,18 @@
 import { createAPI, setListener } from "./api";
-import { sendMessage, setInstanceId } from "./sendMessage";
+import { FDC3LocalInstance } from "./sendMessage";
 import { RegisterInstanceReturn } from "@/common/types";
 import { DesktopAgent } from "@finos/fdc3";
 
 export const createWebAgentAPI = async (): Promise<DesktopAgent> => {
-  setListener();
-
-  const registrationResult = await sendMessage("registerInstance");
+  
+  //instantiate a local instance
+  const connection = new FDC3LocalInstance();
+  connection.setListener();
+  const registrationResult = await connection.sendMessage("registerInstance");
   const instanceId = (registrationResult.data as RegisterInstanceReturn)
     .instanceId;
-  setInstanceId(instanceId);
+  console.log("*** API setting instanceId ", instanceId);
+  connection.instanceId = instanceId;
 
-  return createAPI();
+  return createAPI(connection);
 };

--- a/src/webAgentAPI/sendMessage.ts
+++ b/src/webAgentAPI/sendMessage.ts
@@ -8,6 +8,8 @@ import {
 import { TOPICS } from "@/common/topics";
 import { guid } from "@/common/util";
 import { Context } from '@finos/fdc3';
+import { RegisterInstanceReturn } from "@/common/types";
+
 
 export class FDC3LocalInstance {
 
@@ -16,8 +18,18 @@ export class FDC3LocalInstance {
   returnHandlers: Map<string, any> = new Map();
 
   constructor() {
-  
+
   }
+
+  initConnection = async () => {
+    this.setListener();
+    const registrationResult = await this.sendMessage("registerInstance");
+    const instanceId = (registrationResult.data as RegisterInstanceReturn)
+      .instanceId;
+    console.log("*** API setting instanceId ", instanceId);
+    this.instanceId = instanceId;
+  }
+
   contextListeners: Map<string, ListenerItem> = new Map();
 
   intentListeners: Map<string, Map<string, ListenerItem>> = new Map();

--- a/src/webAgentAPI/sendMessage.ts
+++ b/src/webAgentAPI/sendMessage.ts
@@ -2,41 +2,75 @@ import {
   FDC3MessageData,
   FDC3ReturnMessage,
   FDC3SendMessageResolution,
+  ListenerItem,
+  ContextMessage
 } from "@/common/types";
+import { TOPICS } from "@/common/topics";
 import { guid } from "@/common/util";
+import { Context } from '@finos/fdc3';
 
-const returnHandlers: Map<string, any> = new Map();
-let instanceId: string | undefined;
+export class FDC3LocalInstance {
 
-export const getReturnHandlers = (): Map<string, any> => {
-  return returnHandlers;
-};
+  instanceId : string | undefined;
 
-export const setInstanceId = (id: string) => {
-  instanceId = id;
-};
+  returnHandlers: Map<string, any> = new Map();
 
-export const sendMessage = (
-  topic: string,
-  data?: FDC3MessageData,
-  handler?: any
-): Promise<FDC3SendMessageResolution> => {
-  return new Promise((resolve) => {
-    const returnId = `${topic}_${guid()}`;
-    const theHandler = async (message: FDC3ReturnMessage) => {
-      if (handler) {
-        resolve(await handler.call(this, data));
+  constructor() {
+  
+  }
+  contextListeners: Map<string, ListenerItem> = new Map();
+
+  intentListeners: Map<string, Map<string, ListenerItem>> = new Map();
+
+  setListener = () => {
+    window.addEventListener("message", async (event: MessageEvent) => {
+      const message: FDC3ReturnMessage = event.data || ({} as FDC3ReturnMessage);
+      if (message.topic === TOPICS.CONTEXT && message.data) {
+        const contextMessage : ContextMessage = message.data as ContextMessage;
+    
+        if (this.contextListeners.has(contextMessage.listenerId)){
+          const listener = this.contextListeners.get(contextMessage.listenerId);
+          listener?.handler?.call(this, (message.data as ContextMessage).context as Context);
+        }
       }
-      resolve({ data: message.data || {}, error: message.error });
-    };
-    returnHandlers.set(returnId, theHandler);
-    const source = instanceId;
-    //do everything through window messages?
-    window.top?.postMessage({
-      topic,
-      source,
-      returnId,
-      data,
+  
+      const returnHandlers = this.getReturnHandlers();
+      if (returnHandlers.has(message.topic)) {
+        return returnHandlers.get(message.topic).call(this, { data: message.data });
+      }
     });
-  });
-};
+  }
+
+  getReturnHandlers() : Map<string, any>  {
+    return this.returnHandlers;
+  }
+
+  sendMessage(
+    topic: string,
+    data?: FDC3MessageData,
+    handler?: any
+  ): Promise<FDC3SendMessageResolution>  {
+    return new Promise((resolve) => {
+      const returnId = `${topic}_${guid()}`;
+      const theHandler = async (message: FDC3ReturnMessage) => {
+        if (handler) {
+          resolve(await handler.call(this, data));
+        }
+        resolve({ data: message.data || {}, error: message.error });
+      };
+      this.returnHandlers.set(returnId, theHandler);
+      const source = this.instanceId;
+      //do everything through window messages?
+      console.log('***API posting message', topic, source, data);
+      window.top?.postMessage({
+        topic,
+        source,
+        returnId,
+        data,
+      });
+    });
+  }
+
+}
+
+


### PR DESCRIPTION
There was an issue with the way that the instance ids and other connection related state for the local FDC3 instance scopes were being handled.  They were just scoped to module - which worked fine when separation of apps were by iframe - but in the same DOM - these modules get shared - so the instances were colliding.  Created a separate 'FDC3LocalInstance' class for handling all instance state - now, each API instance get's one of these and is able to maintain its own scope.  

Tested for both same DOM and iFrames - everything working as expected.  Created a new test page for single DOM instance (localhost:5173/components.html).  

@alj1s @bschwinn 