### PR TITLE
fix: update usages of postMessage to set targetOrigin parameter

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -35,7 +35,7 @@ export interface LocalInstance {
   contextListeners: Map<string, ContextListener>;
   intentListeners: Map<string, IntentListener>;
   channelListener?: Listener; //listener to proxy for the 'joined' channel
-  source: MessageEventSource | null;
+  source: Window | null;
 }
 
 export interface ChannelInstance {

--- a/src/webAgent/handlers/broadcast.ts
+++ b/src/webAgent/handlers/broadcast.ts
@@ -51,7 +51,7 @@ export const broadcast = async (localAgent: WebAgent, message: FDC3Message) => {
               channel: messageData.channel,
               listenerId: listenerId,
             },
-          });
+          }, "*");
         }
       });
     }

--- a/src/webAgent/handlers/channels.ts
+++ b/src/webAgent/handlers/channels.ts
@@ -150,7 +150,7 @@ export const joinChannel = async (
             context: context,
             listenerId: listenerId,
           },
-        });
+        }, "*");
       }
     });
   };
@@ -178,7 +178,7 @@ export const joinChannel = async (
             context: current,
             listenerId: listenerId,
           },
-        });
+        }, "*");
       }
     });
   }

--- a/src/webAgent/handlers/contextListeners.ts
+++ b/src/webAgent/handlers/contextListeners.ts
@@ -30,7 +30,7 @@ export const addContextListener = async (
             channel: messageData.channel,
             listenerId: messageData.listenerId,
           },
-        });
+        }, "*");
       }
     }
   };
@@ -49,7 +49,7 @@ export const addContextListener = async (
             channel: messageData.channel,
             listenerId: messageData.listenerId,
           },
-        });
+        }, "*");
       },
     });
 

--- a/src/webAgent/main.ts
+++ b/src/webAgent/main.ts
@@ -81,7 +81,7 @@ export class WebAgent {
     // set up message listener
     window.addEventListener("message", async (event: MessageEvent) => {
       const message: FDC3Message = event.data || ({} as FDC3Message);
-      const messageSource = event.source;
+      const messageSource = event.source as Window;
       if (message.topic === "registerInstance") {
         // handle registration
         this.handleRegistration(message, messageSource);
@@ -105,7 +105,7 @@ export class WebAgent {
   // handle web agent api registration
   handleRegistration(
     message: FDC3Message,
-    messageSource: MessageEventSource | null
+    messageSource: Window | null
   ) {
     // generate a guid
     const instanceId = guid();
@@ -129,7 +129,7 @@ export class WebAgent {
   // send back the instanceId to the api
   sendHandshake(
     message: FDC3Message,
-    messageSource: MessageEventSource | null,
+    messageSource: Window | null,
     instanceId: string
   ) {
     messageSource?.postMessage({
@@ -137,12 +137,12 @@ export class WebAgent {
       data: {
         instanceId: instanceId,
       },
-    });
+    }, "*");
   }
 
   async handleMessage(
     message: FDC3Message,
-    messageSource: MessageEventSource | null
+    messageSource: Window | null
   ) {
     const handler = this.handlers.get(message.topic);
     if (handler) {
@@ -152,7 +152,7 @@ export class WebAgent {
         ...result,
       };
       //send a return message
-      messageSource?.postMessage(returnMessage);
+      messageSource?.postMessage(returnMessage, "*");
     }
   }
 }

--- a/src/webAgentAPI/sendMessage.ts
+++ b/src/webAgentAPI/sendMessage.ts
@@ -108,7 +108,7 @@ export class FDC3LocalInstance {
         source,
         returnId,
         data,
-      });
+      }, "*");
     });
   }
 }


### PR DESCRIPTION
Updated all calls to `postMessage` to pass a `targetOrigin` of '*'.

In some cases, the `postMessage` call is made against the source object of a previous message. In general, this could be any `MessageEventSource` (e.g. `WindowProxy`, `ServiceWorker` or `MessagePort`). However, under the current implementation, it would only be possible to be another `Window` object so I have narrowed the typing accordingly.

It may be that this is not an appropriate simplification and as the `postMessage` function is polymorphic, we may need to add some additional checking based on the original message source.

Happy to discuss if you think an alternative approach would be better.